### PR TITLE
Update packet handler: RoomPlayer

### DIFF
--- a/src/structures/RoomPlayer.ts
+++ b/src/structures/RoomPlayer.ts
@@ -142,6 +142,9 @@ export default class RoomPlayer extends Player {
 		packet.readUnsignedInt(); // Unknown int
 		const color = packet.readUnsignedInt();
 		this.nameColor = color === 0xffffffff ? -1 : color;
+		
+		packet.readByte(); // Unknown byte
+		
 		return this;
 	}
 }


### PR DESCRIPTION
It seems a single byte was added to the end of `RoomPlayer`.
The `playerRoomList` packet contains multiple of these in sequence, so reading this new byte is necessary to get the offsets right.
https://github.com/cheeseformice/transformice.js/blob/1a8804a4057c730f68676d7c2340b8fa2c707135/src/client/PacketHandler.ts#L137-L140